### PR TITLE
Load JQuery via HTTPS (Better Firefox support)

### DIFF
--- a/demo/demo.html
+++ b/demo/demo.html
@@ -7,7 +7,7 @@
 	<base href=".."></base>
 
 	<script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.0.8/angular.min.js"></script>
-	<script src="http://code.jquery.com/jquery-1.10.1.min.js"></script>
+	<script src="https://code.jquery.com/jquery-1.10.1.min.js"></script>
 	<script src="src/twitter-timeline.js"></script>
 	<script>
 		var app = angular.module('demoApp', ['twitter.timeline']);


### PR DESCRIPTION
Fixes issue of Firefox 42.0 refusing to load the JQuery code when viewed as https.  This comes from a [Stack Overflow question](https://stackoverflow.com/questions/34294989/impossible-to-use-a-twitter-timeline-in-firefox).  Don't forget to update the master branch too.
